### PR TITLE
Rewrite most loop constructs to use reduce

### DIFF
--- a/core/src/main/cljc/jarl/parser.cljc
+++ b/core/src/main/cljc/jarl/parser.cljc
@@ -221,8 +221,7 @@
 
 (defn make-stmts [stmts-info]
   (log/debug "making stmts")
-  (let [stmts (doall (for [stmt-info stmts-info]
-                       (make-stmt stmt-info)))]
+  (let [stmts (mapv make-stmt stmts-info)]
     (fn [state]
       (eval/eval-stmts stmts state))))
 
@@ -234,8 +233,7 @@
 
 (defn make-blocks [blocks-info]
   (log/debug "making blocks")
-  (let [blocks (doall (for [block-info blocks-info]
-                        (make-block block-info)))]
+  (let [blocks (mapv make-block blocks-info)]
     (fn [state]
       (eval/eval-blocks blocks state))))
 
@@ -271,8 +269,7 @@
 
 (defn make-plans [{:strs [plans]}]
   (log/debug "making plans")
-  (into-array (doall (for [plan-info plans]
-                       (make-plan plan-info)))))
+  (mapv make-plan plans))
 
 (defn make-func [{:strs [name path params] return-index "return" blocks-info "blocks"}]
   (let [blocks (make-blocks blocks-info)]

--- a/core/src/test/cljc/test/compliance/runtime.cljc
+++ b/core/src/test/cljc/test/compliance/runtime.cljc
@@ -23,18 +23,14 @@
     (reduce eval-entry-point {} entry-points)))
 
 (defn eval-entry-points-for-errors [info entry-points data input]
-  (loop [entry-points entry-points
-         errors []]
-    (if (empty? entry-points)
-      errors
-      (let [entry-point (first entry-points)
-            plan (get-plan (get info :plans) entry-point)
-            errors (try
-                     (plan info data input)                 ; We don't care about the result set
-                     errors
-                     (catch ExceptionInfo e                 ; Blow up on non-jarl exceptions
-                       (conj errors e)))]
-        (recur (next entry-points) errors)))))
+  (let [try-error (fn [errors entry-point]
+                     (let [plan (get-plan (get info :plans) entry-point)]
+                       (try
+                         (plan info data input)                 ; We don't care about the result set
+                         errors
+                         (catch ExceptionInfo e                 ; Blow up on non-jarl exceptions
+                           (conj errors e)))))]
+    (reduce try-error [] entry-points)))
 
 (defn- match-one-of [provided-msg expected-msg]
   (when (and (str/includes? provided-msg "one of") (str/includes? expected-msg "one of"))


### PR DESCRIPTION
`reduce` is more idiomatic, and likely more performant as it uses transient values underneath

Signed-off-by: Anders Eknert <anders@eknert.com>