### PR TITLE
http.send caching

### DIFF
--- a/core/src/main/cljc/jarl/builtins/http.cljc
+++ b/core/src/main/cljc/jarl/builtins/http.cljc
@@ -3,20 +3,24 @@
             [clojure.set :as set]
             [clojure.string :as str]
             [clojure.walk :as walk]
+            [tick.core :as t]
             [jarl.builtins.utils :as utils]
             [jarl.exceptions :as errors]
             [jarl.encoding.json :as json]
             [jarl.encoding.yaml :as yaml]
-            [jarl.http-client :as http-client]))
+            [jarl.http-client :as http-client]
+            [jarl.time :as time]))
 
 (def ^:private default-req-timeout 5000)
 
 (def inter-query-cache (atom {}))
 
-(defn force-cache? [req]
+(defn- force-cache? [req]
   (and (:force-cache req)
-       (:force-cache-duration-seconds req)
-       (> (:force-cache-duration-seconds req) 0)))
+       (pos-int? (:force-cache-duration-seconds req))))
+
+(defn cache? [req]
+  (or (force-cache? req) (:cache req)))
 
 (defn status-code->status-text [code]
   (case code
@@ -169,6 +173,7 @@
             (has? "raw_body")                     (assoc :body (req "raw_body"))
             (has? "headers")                      (assoc :headers (req "headers"))
             (has? "timeout")                      (assoc :conn-timeout (parse-timeout (req "timeout"))) ; millis here, not OPA nanos
+            (has? "cache")                        (assoc :cache (req "cache"))
             (has? "force_cache")                  (assoc :force-cache (req "force_cache"))
             (has? "force_cache_duration_seconds") (assoc :force-cache-duration-seconds (req "force_cache_duration_seconds"))
             (has? "force_json_decode")            (assoc :force-json-decode (req "force_json_decode"))
@@ -203,17 +208,54 @@
                   "raw_body"    (:body response)}]
         resp))))
 
-(defn maybe-cache [res req]
-  (when (force-cache? req)
-    (swap! inter-query-cache assoc (hash req) res))
-  res)
+(defn- date [res]
+  (when-let [date (get-in res [:headers "date"])]
+    (time/http-date->instant date)))
+
+(defn- max-age [res]
+  (when-let [cc (get-in res [:headers "cache-control"])]
+    (first (->> (str/split (str/lower-case cc) #",")
+                (remove str/blank?)
+                (map str/trim)
+                (map #(str/split % #"="))
+                (filter #(= "max-age" (first %)))
+                (map second)
+                (map parse-long)))))
+
+(defn- exp-from-headers [res]
+  (if-let [max-age (max-age res)]
+    (some-> (date res) (t/>> (t/new-duration max-age :seconds)))
+    (-> res (get-in [:headers "expires"]) time/http-date->instant)))
+
+(defn- expires-at [{now :time-now-ns} req res]
+  (if (force-cache? req)
+    (t/>> (time/ns->instant now)
+          (t/new-duration (:force-cache-duration-seconds req) :seconds))
+    (or (exp-from-headers res)
+        (time/ns->instant now))))
+
+(defn- maybe-cache [bctx res req]
+  (let [res (cond-> res (:headers res) (update :headers update-keys str/lower-case))]
+    (when (cache? req)
+      (:response (swap! inter-query-cache assoc (hash req) {:response res :exp (expires-at bctx req res)})))
+    res))
+
+; side effect - may remove stale item from cache
+(defn- check-cache [{now :time-now-ns} key]
+  (when (contains? @inter-query-cache key)
+    (let [item (get @inter-query-cache key)
+          exp  (:exp item)]
+      (if (t/>= (time/ns->instant now) exp)
+        (do ; cache item is stale — remove and return nil to fetch anew
+          (swap! inter-query-cache dissoc key)
+          nil)
+        (:response item)))))
 
 (defn builtin-http-send
-  [{[request] :args}]
+  [{[request] :args bctx :builtin-context}]
   (validate-request request)
   (let [req (create-request request)
         key (hash req)
-        res (if (contains? @inter-query-cache key)
-              (get @inter-query-cache (hash req))
-              (-> req http-client/send-request (maybe-cache req)))]
+        res (or (check-cache bctx key)
+                (maybe-cache bctx (http-client/send-request req) req))]
     (create-response req res)))

--- a/core/src/main/cljc/jarl/builtins/time.cljc
+++ b/core/src/main/cljc/jarl/builtins/time.cljc
@@ -4,101 +4,7 @@
             [tick.locale-en-us]
             [tick.timezone]
             [jarl.exceptions :as errors]
-            [jarl.utils :refer [instant->ns ns->instant]]))
-
-(def iso-zoned-date-time-fmt (t/predefined-formatters :iso-zoned-date-time))
-(def iso-local-date-time-fmt (t/predefined-formatters :iso-local-date-time))
-
-; Courtesy of https://github.com/newm4n/go-dfe
-(def ^:private go->java-map
-  {; Go          Java
-   "January"   "MMMM"
-   "Jan"       "MMM"
-   "1"         "M"
-   "01"        "MM"
-   "Monday"    "EEEE"
-   "Mon"       "EEE"
-   "2"         "d"
-   "_2"        "_d"
-   "02"        "dd"
-   "15"        "HH"
-   "3"         "K"
-   "03"        "KK"
-   "4"         "m"
-   "04"        "mm"
-   "5"         "s"
-   "05"        "ss"
-   "2006"      "yyyy"
-   "06"        "yy"
-   "PM"        "aa"
-   "pm"        "aa"
-   "MST"       "Z"
-   "Z0700"     "'Z'XX"
-   "Z070000"   "'Z'XX"
-   "Z07"       "'Z'X"
-   "Z07:00"    "'Z'XXX"
-   "Z07:00:00" "'Z'XXX"
-   "-0700"     "XX"
-   "-070000"   "'Z'XX"
-   "-07"       "X"
-   "-07:00"    "XXX"
-   "-07:00:00" "XXX"
-   "999999999" "SSS"})
-
-(defn- key-length-sorter
-  "Sort by key length (with the longest first) but treat equal key length as different in order to not discard them"
-  [x y]
-  (let [cmp (compare (count y) (count x))]
-    (if (zero? cmp) -1 cmp)))
-
-(def ^:private go->java-sorted-map (into (sorted-map-by key-length-sorter) go->java-map))
-
-(defn- go->java-formatter ^String [format]
-  (reduce (fn [acc [go java]] (str/replace acc go java)) format go->java-sorted-map))
-
-(defn parse-iso-datetime
-  ([s]
-   (parse-iso-datetime s iso-local-date-time-fmt))
-  ([s f]
-   (-> (errors/try-or #(t/parse-date-time s f) (t/beginning (t/parse-date s f))) ; if only date, i.e. 2012-12-12
-       (t/in "UTC")
-       t/instant)))
-
-(defn parse-iso-zoned-datetime
-  ([s]
-   (parse-iso-zoned-datetime s iso-zoned-date-time-fmt))
-  ([s f]
-   (-> s (t/parse-zoned-date-time f) t/instant)))
-
-#?(:clj
-   (def ^:private jvm-major-version
-     (let [jvm-version (System/getProperty "java.vm.version")]
-       (parse-long (subs jvm-version 0 (str/index-of jvm-version "."))))))
-
-#?(:clj
-   (defn- fixup-am-pm
-     "Workaround for weird behavior in Java date time parsing, where AM/PM vs. am/pm is expected depending on JVM version"
-     [s]
-     (if (> jvm-major-version 11)
-       (-> s (str/replace "AM" "am") (str/replace "PM" "pm"))
-       (-> s (str/replace "am" "AM") (str/replace "pm" "PM")))))
-
-(defn parse-formatted-datetime [s f]
-  (if (= f "01/02 03:04:05PM '06 -0700")
-        ; special case for what Go docs refer to as "reference time": 01/02 03:04:05PM '06 -0700
-        ; https://pkg.go.dev/time#pkg-constants
-        (parse-iso-zoned-datetime #?(:clj  (str/replace (fixup-am-pm s) #"'" "")
-                                     :cljs (str/replace s #"'" ""))
-                                  (t/formatter "MM/dd hh:mm:ssa yy XX"))
-    ; everything else
-    (let [pattern (go->java-formatter f)]
-      (if (re-find #"[ZXx]" pattern) ; time zone in pattern
-        ; TODO: figure out why errors/try-or doesn't work in this context
-        (try
-          (parse-iso-zoned-datetime s (t/formatter pattern))
-          #?(:clj  (catch Throwable _ (parse-iso-zoned-datetime s))
-             :cljs (catch js/Object _ (parse-iso-zoned-datetime s))))
-        (parse-iso-datetime s (t/formatter pattern))))))
+            [jarl.time :as time]))
 
 (def unit->temporal
   {"h"  :hours
@@ -120,16 +26,22 @@
         tz (second arr)]
     (-> (errors/try-or-throw #(long (first arr))
                              (errors/builtin-ex "timestamp too big"))
-        ns->instant
+        time/ns->instant
         (t/in (if (empty? tz) "UTC" tz)))))
+
+(defn- unknown-duration-ex [unit time]
+  (errors/builtin-ex "time: unknown unit \"%s\" in duration \"%s\"" unit (str time unit)))
+
+(defn- ->duration [[_ time unit]]
+  (d (parse-long time) (errors/get-or-throw unit->temporal unit (unknown-duration-ex unit time))))
 
 (defn builtin-time-add-date
   [{[^long ns ^long years ^long months ^long days] :args}]
-  (let [result (instant->ns (-> (t/in (ns->instant ns) "UTC")
-                                (t/>> (t/of-years years))
-                                (t/>> (t/of-months months))
-                                (t/>> (t/of-days days))
-                                (t/instant)))]
+  (let [result (time/instant->ns (-> (t/in (time/ns->instant ns) "UTC")
+                                     (t/>> (t/of-years years))
+                                     (t/>> (t/of-months months))
+                                     (t/>> (t/of-days days))
+                                     (t/instant)))]
     (errors/try-or-throw #(long result) (errors/builtin-ex "time outside of valid range"))))
 
 (defn builtin-time-clock
@@ -152,12 +64,6 @@
   [{[x] :args}]
   (-> x ns-with-tz t/day-of-week str str/capitalize))
 
-(defn unknown-duration-ex [unit time]
-  (errors/builtin-ex "time: unknown unit \"%s\" in duration \"%s\"" unit (str time unit)))
-
-(defn ->duration [[_ time unit]]
-  (d (parse-long time) (errors/get-or-throw unit->temporal unit (unknown-duration-ex unit time))))
-
 (defn builtin-time-parse-duration-ns
   [{[s] :args}]
   (let [s (str/replace s "µ" "u")] ; Javascript regex doesn't like unicode, and at least here, it doesn't matter
@@ -170,10 +76,10 @@
 
 (defn builtin-time-parse-ns
   [{[layout value] :args}]
-  (let [nanos (instant->ns (parse-formatted-datetime value layout))]
+  (let [nanos (time/instant->ns (time/parse-formatted-datetime value layout))]
     (errors/try-or-throw #(long nanos) (errors/builtin-ex "time outside of valid range"))))
 
 (defn builtin-time-parse-rfc3339-ns
   [{[s] :args}]
-  (let [nanos (instant->ns (parse-iso-zoned-datetime s))]
+  (let [nanos (time/instant->ns (time/parse-iso-zoned-datetime s))]
     (errors/try-or-throw #(long nanos) (errors/builtin-ex "time outside of valid range"))))

--- a/core/src/main/cljc/jarl/state.cljc
+++ b/core/src/main/cljc/jarl/state.cljc
@@ -1,6 +1,7 @@
 (ns jarl.state
   (:require [taoensso.timbre :as log]
             [jarl.runtime.environment :as environment]
+            [jarl.time :as time]
             [jarl.utils :as utils]))
 
 (defn- upsert-local [value stack index]
@@ -87,7 +88,7 @@
 (defn init-state [info input data]
   (cond-> info
           ; if builtin-context has been provided already, use that
-          (not (contains? info :builtin-context)) (assoc :builtin-context {:time-now-ns (utils/time-now-ns)
+          (not (contains? info :builtin-context)) (assoc :builtin-context {:time-now-ns (time/now-ns)
                                                                            :env         environment/*env*})
           true (assoc :local (cond-> {}
                                      (some? input) (assoc 0 input)

--- a/core/src/main/cljc/jarl/time.cljc
+++ b/core/src/main/cljc/jarl/time.cljc
@@ -1,0 +1,122 @@
+(ns jarl.time
+  (:require [clojure.string :as str]
+            [cljc.java-time.instant :as i]
+            [tick.core :as t]
+            [tick.locale-en-us]
+            [jarl.exceptions :as errors]))
+
+(def ^:private iso-zoned-date-time-fmt (t/predefined-formatters :iso-zoned-date-time))
+(def ^:private iso-local-date-time-fmt (t/predefined-formatters :iso-local-date-time))
+(def ^:private rfc-1123-fmt            (t/formatter "EEE, dd MMM yyyy HH:mm:ss zzz"))  ; Mon, 02 Jan 2006 15:04:05 GMT
+(def ^:private rfc-850-fmt             (t/formatter "EEEE, dd-MMM-yy HH:mm:ss zzz"))   ; Monday, 02-Jan-06 15:04:05 MST
+
+; Courtesy of https://github.com/newm4n/go-dfe
+(def ^:private go->java-map
+  {; Go          Java
+   "January"   "MMMM"
+   "Jan"       "MMM"
+   "1"         "M"
+   "01"        "MM"
+   "Monday"    "EEEE"
+   "Mon"       "EEE"
+   "2"         "d"
+   "_2"        "_d"
+   "02"        "dd"
+   "15"        "HH"
+   "3"         "K"
+   "03"        "KK"
+   "4"         "m"
+   "04"        "mm"
+   "5"         "s"
+   "05"        "ss"
+   "2006"      "yyyy"
+   "06"        "yy"
+   "PM"        "aa"
+   "pm"        "aa"
+   "MST"       "Z"
+   "Z0700"     "'Z'XX"
+   "Z070000"   "'Z'XX"
+   "Z07"       "'Z'X"
+   "Z07:00"    "'Z'XXX"
+   "Z07:00:00" "'Z'XXX"
+   "-0700"     "XX"
+   "-070000"   "'Z'XX"
+   "-07"       "X"
+   "-07:00"    "XXX"
+   "-07:00:00" "XXX"
+   "999999999" "SSS"})
+
+(defn- key-length-sorter
+  "Sort by key length (with the longest first) but treat equal key length as different in order to not discard them"
+  [x y]
+  (let [cmp (compare (count y) (count x))]
+    (if (zero? cmp) -1 cmp)))
+
+(def ^:private go->java-sorted-map (into (sorted-map-by key-length-sorter) go->java-map))
+
+(defn- go->java-formatter ^String [format]
+  (reduce (fn [acc [go java]] (str/replace acc go java)) format go->java-sorted-map))
+
+(defn instant->ns [instant]
+  #?(:clj  (+' (*' (i/get-epoch-second instant) 1000000000) (t/nanosecond instant))
+     :cljs (+  (*  (i/get-epoch-second instant) 1000000000) (t/nanosecond instant))))
+
+(defn ns->instant [ns]
+  (i/of-epoch-second 0 ns))
+
+(defn now-ns
+  "Current time nanos — not as precise as its OPA/Go equivalent function, but not in any way that matters"
+  []
+  (instant->ns (t/now)))
+
+(defn parse-iso-zoned-datetime
+  ([s]
+   (parse-iso-zoned-datetime s iso-zoned-date-time-fmt))
+  ([s f]
+   (-> s (t/parse-zoned-date-time f) t/instant)))
+
+(defn parse-iso-datetime
+  ([s]
+   (parse-iso-datetime s iso-local-date-time-fmt))
+  ([s f]
+   (-> (errors/try-or #(t/parse-date-time s f) (t/beginning (t/parse-date s f))) ; if only date, i.e. 2012-12-12
+       (t/in "UTC")
+       t/instant)))
+
+#?(:clj
+   (def ^:private jvm-major-version
+     (let [jvm-version (System/getProperty "java.vm.version")]
+       (parse-long (subs jvm-version 0 (str/index-of jvm-version "."))))))
+
+#?(:clj
+   (defn- fixup-am-pm
+     "Workaround for weird behavior in Java date time parsing, where AM/PM vs. am/pm is expected depending on JVM version"
+     [s]
+     (if (> jvm-major-version 11)
+       (-> s (str/replace "AM" "am") (str/replace "PM" "pm"))
+       (-> s (str/replace "am" "AM") (str/replace "pm" "PM")))))
+
+(defn parse-formatted-datetime [s f]
+  (if (= f "01/02 03:04:05PM '06 -0700")
+    ; special case for what Go docs refer to as "reference time": 01/02 03:04:05PM '06 -0700
+    ; https://pkg.go.dev/time#pkg-constants
+    (parse-iso-zoned-datetime #?(:clj  (str/replace (fixup-am-pm s) #"'" "")
+                                      :cljs (str/replace s #"'" ""))
+                                   (t/formatter "MM/dd hh:mm:ssa yy XX"))
+    ; everything else
+    (let [pattern (go->java-formatter f)]
+      (if (re-find #"[ZXx]" pattern) ; time zone in pattern
+        ; TODO: figure out why errors/try-or doesn't work in this context
+        (try
+          (parse-iso-zoned-datetime s (t/formatter pattern))
+          #?(:clj  (catch Throwable _ (parse-iso-zoned-datetime s))
+             :cljs (catch js/Object _ (parse-iso-zoned-datetime s))))
+        (parse-iso-datetime s (t/formatter pattern))))))
+
+; Note: ignore the ANSIC date format as nobody should be using that
+(defn http-date->instant [date]
+  (when (some? date)
+    (if-let [zdt (errors/try-or #(t/parse-zoned-date-time date rfc-1123-fmt) nil)]
+      (t/instant zdt)
+      (when-let [zdt (errors/try-or #(t/parse-zoned-date-time date rfc-850-fmt) nil)]
+        (t/instant zdt)))))

--- a/core/src/main/cljc/jarl/utils.cljc
+++ b/core/src/main/cljc/jarl/utils.cljc
@@ -1,7 +1,5 @@
 (ns jarl.utils
   (:require [clojure.walk :as walk]
-            [cljc.java-time.instant :as i]
-            [tick.core :as t]
             #?(:cljs [clojure.string :as str])
             #?(:cljs [cljs.math])
             #?(:cljs [jarl.types :as types]))
@@ -31,18 +29,6 @@
     (if ks
       (update m k indiscriminate-assoc-in ks v)
       (assoc m k v))))
-
-(defn instant->ns [instant]
-  #?(:clj  (+' (*' (i/get-epoch-second instant) 1000000000) (t/nanosecond instant))
-     :cljs (+  (*  (i/get-epoch-second instant) 1000000000) (t/nanosecond instant))))
-
-(defn ns->instant [ns]
-  (i/of-epoch-second 0 ns))
-
-(defn time-now-ns
-  "Current time nanos — not as precise as its OPA/Go equivalent function, but not in any way that matters"
-  []
-  (instant->ns (t/now)))
 
 ; Some tricks / hacks for unicode handling in Javascript / ClojureScript:
 ; https://dev.to/coolgoose/quick-and-easy-way-of-counting-utf-8-characters-in-javascript-23ce

--- a/core/src/test/clj/jarl/builtins/jwt_test.clj
+++ b/core/src/test/clj/jarl/builtins/jwt_test.clj
@@ -1,7 +1,7 @@
 (ns jarl.builtins.jwt-test
   (:require [clojure.test :refer [deftest testing is]]
             [jarl.builtins.jwt :as jwt]
-            [jarl.utils :refer [time-now-ns]])
+            [jarl.time :refer [now-ns]])
   (:import (java.util.concurrent TimeUnit)))
 
 ; some basic sanity tests here only - mainly tested by the compliance suite
@@ -31,7 +31,7 @@
 
 (deftest verify-time-test
   (testing "nbf and exp"
-    (let [now (time-now-ns)
+    (let [now (now-ns)
           nbf (dec (nanos->seconds now))
           exp (inc (nanos->seconds now))]
       (is (= (jwt/verify-time {"exp" exp "nbf" nbf} {"time" now}) true)))))

--- a/core/src/test/cljc/jarl/builtins/http_test.cljc
+++ b/core/src/test/cljc/jarl/builtins/http_test.cljc
@@ -1,10 +1,12 @@
 (ns jarl.builtins.http-test
-    (:require [jarl.builtins.http  :refer [builtin-http-send content-type create-request parse-timeout]]
-              [jarl.exceptions     :as errors]
-              [jarl.types          :refer [rego-equal?]]
-              [jarl.http-client    :as http-client]
+  (:require [jarl.builtins.http :refer [builtin-http-send content-type create-request parse-timeout]]
+            [jarl.exceptions :as errors]
+            [jarl.types :refer [rego-equal?]]
+            [jarl.http-client :as http-client]
+            [jarl.time :as time]
             #?(:clj  [clojure.test :refer [deftest is testing]]
-               :cljs [cljs.test    :refer [deftest is testing]])))
+               :cljs [cljs.test :refer [deftest is testing]])
+            [tick.core :as t]))
 
 (deftest content-type-test
   (testing "parsing content type"
@@ -22,38 +24,44 @@
 
 (deftest create-request-test
   (testing "create request, default values"
-    (is (= (create-request     {"method" "get" "url" "https://foo.bar"})
-           {:follow-redirects  false
-            :force-json-decode false
-            :force-yaml-decode false
-            :insecure?         false
-            :raise-error       true
-            :conn-timeout      5000
-            :method            :get
-            :url               "https://foo.bar"})))
+    (is (= (create-request                {"method" "get" "url" "https://foo.bar"})
+           {:follow-redirects             false
+            :force-cache                  false
+            :force-cache-duration-seconds 0
+            :force-json-decode            false
+            :force-yaml-decode            false
+            :insecure?                    false
+            :raise-error                  true
+            :conn-timeout                 5000
+            :method                       :get
+            :url                          "https://foo.bar"})))
 
   (testing "create request, modified values"
     (is (= (create-request
-             {"method"                    "PUT"
-              "url"                       "https://foo.bar"
-              "enable_redirect"           true
-              "force_yaml_decode"         true
-              "tls_insecure_skip_verify"  true
-              "timeout"                   "1s500ms"
-              "raise_error"               false})
-           {:follow-redirects  true
-            :force-json-decode false
-            :force-yaml-decode true
-            :insecure?         true
-            :raise-error       false
-            :conn-timeout      1500
-            :method            :put
-            :url               "https://foo.bar"}))))
+             {"method"                        "PUT"
+              "url"                           "https://foo.bar"
+              "force_cache"                   true
+              "force_cache_duration_seconds"  15
+              "enable_redirect"               true
+              "force_yaml_decode"             true
+              "tls_insecure_skip_verify"      true
+              "timeout"                       "1s500ms"
+              "raise_error"                   false})
+           {:follow-redirects             true
+            :force-cache                  true
+            :force-cache-duration-seconds 15
+            :force-json-decode            false
+            :force-yaml-decode            true
+            :insecure?                    true
+            :raise-error                  false
+            :conn-timeout                 1500
+            :method                       :put
+            :url                          "https://foo.bar"}))))
 
 (deftest http-send-test
   (testing "basic response handling"
     (with-redefs [http-client/send-request (fn [_] {:status 200 :headers {} :body "no coercion"})]
-      (is (= (builtin-http-send {:args [{"method" "get" "url" "http://borge.by"}]})
+      (is (= (builtin-http-send {:args [{"method" "get" "url" "http://borge.by"}] :builtin-context {:time-now-ns 1}})
              {"body"        nil
               "headers"     {}
               "raw_body"    "no coercion"
@@ -64,7 +72,7 @@
     (with-redefs [http-client/send-request (fn [_] {:status 200
                                                     :headers {"content-type" "application/json"}
                                                     :body "{\"foo\":\"bar\"}"})]
-      (is (= (builtin-http-send {:args [{"method" "get" "url" "http://borge.by"}]})
+      (is (= (builtin-http-send {:args [{"method" "get" "url" "http://borge.by"}] :builtin-context {:time-now-ns 1}})
              {"body"        {"foo" "bar"}
               "headers"     {"content-type" "application/json"}
               "raw_body"    "{\"foo\":\"bar\"}"
@@ -73,7 +81,8 @@
 
   (testing "force json decode"
     (with-redefs [http-client/send-request (fn [_] {:status 200 :headers {} :body "{\"foo\":\"bar\"}"})]
-      (is (= (builtin-http-send {:args [{"method" "get" "url" "http://borge.by" "force_json_decode" true}]})
+      (is (= (builtin-http-send {:args [{"method" "get" "url" "http://borge.by" "force_json_decode" true}]
+                                 :builtin-context {:time-now-ns 1}})
              {"body"        {"foo" "bar"}
               "headers"     {}
               "raw_body"    "{\"foo\":\"bar\"}"
@@ -89,21 +98,107 @@
                       {:status 200 :headers {"content-type" "application/json"} :body "{\"foo\":\"bar\"}"})]
         (let [res {"body" {"foo" "bar"} "headers" {"content-type" "application/json"}
                    "raw_body" "{\"foo\":\"bar\"}" "status" "200 OK" "status_code" 200}]
-          (is (= (builtin-http-send {:args [req]}) res))
-          (is (= (builtin-http-send {:args [req]}) res))
-          (is (= (builtin-http-send {:args [req]}) res))
+          (is (= (builtin-http-send {:args [req] :builtin-context {:time-now-ns 1}}) res))
+          (is (= (builtin-http-send {:args [req] :builtin-context {:time-now-ns 1}}) res))
+          (is (= (builtin-http-send {:args [req] :builtin-context {:time-now-ns 1}}) res))
           (is (= @counter 1)))))))
+
+(deftest http-send-caching-test
+  (testing "force cache"
+    (let [counter (atom 0)
+          req {"method" "get" "url" "http://borge.by/foo" "force_cache" true "force_cache_duration_seconds" 30}]
+      (with-redefs [http-client/send-request
+                    (fn [_]
+                      (swap! counter inc)
+                      {:status 200 :headers {"content-type" "application/json"} :body "{\"foo\":\"bar\"}"})]
+        (let [res {"body" {"foo" "bar"} "headers" {"content-type" "application/json"}
+                   "raw_body" "{\"foo\":\"bar\"}" "status" "200 OK" "status_code" 200}]
+          (is (= (builtin-http-send {:args [req] :builtin-context {:time-now-ns 1}}) res))
+          (is (= (builtin-http-send {:args [req] :builtin-context {:time-now-ns 1}}) res))
+          (is (= @counter 1))))))
+
+  (testing "force cache duration"
+    (let [counter (atom 0)
+          req {"method" "get" "url" "http://borge.by/bar" "force_cache" true "force_cache_duration_seconds" 30}]
+      (with-redefs [http-client/send-request
+                    (fn [_]
+                      (swap! counter inc)
+                      {:status 200 :headers {"content-type" "application/json"} :body "{\"foo\":\"bar\"}"})]
+        (let [res {"body" {"foo" "bar"} "headers" {"content-type" "application/json"}
+                   "raw_body" "{\"foo\":\"bar\"}" "status" "200 OK" "status_code" 200}
+              now   (time/now-ns)
+              exp   (time/instant->ns (t/>> (t/now) (t/new-duration 60 :seconds)))
+              bctx {:time-now-ns now}]
+          (is (= (builtin-http-send {:args [req] :builtin-context bctx}) res))
+          (is (= @counter 1))
+          (is (= (builtin-http-send {:args [req] :builtin-context bctx}) res))
+          (is (= @counter 1))
+          (is (= (builtin-http-send {:args [req] :builtin-context {:time-now-ns exp}}) res)) ; fast-forward 1 minute
+          (is (= @counter 2))))))
+
+  (testing "cache from response headers, cache-control"
+    (let [counter (atom 0)
+          req {"method" "get" "url" "http://borge.by" "cache" true}]
+      (with-redefs [http-client/send-request
+                    (fn [_]
+                      (swap! counter inc)
+                      {:status 200
+                       ; note upper-case keys
+                       :headers {"Content-Type" "application/json"
+                                 "Cache-Control" "ignored, max-age=30, also=ignored"
+                                 "Date" "Sat, 01 Jan 2022 15:10:05 GMT"}
+                       :body "{\"foo\":\"bar\"}"})]
+        (let [res {"body" {"foo" "bar"}
+                   "headers" {"content-type" "application/json"
+                              "cache-control" "ignored, max-age=30, also=ignored"
+                              "date" "Sat, 01 Jan 2022 15:10:05 GMT"}
+                   "raw_body" "{\"foo\":\"bar\"}" "status" "200 OK" "status_code" 200}
+              now   (t/instant (t/zoned-date-time "2022-01-01T15:10:05Z"))
+              exp   (time/instant->ns (t/>> now (t/new-duration 60 :seconds)))
+              bctx {:time-now-ns (time/instant->ns now)}]
+          (is (= (builtin-http-send {:args [req] :builtin-context bctx}) res))
+          (is (= @counter 1))
+          (is (= (builtin-http-send {:args [req] :builtin-context bctx}) res))
+          (is (= @counter 1))
+          (is (= (builtin-http-send {:args [req] :builtin-context {:time-now-ns exp}}) res)) ; fast-forward 1 minute
+          (is (= @counter 2))))))
+
+  (testing "cache from response headers, expires"
+    (let [counter (atom 0)
+          req {"method" "get" "url" "http://borge.by/jarl" "cache" true}]
+      (with-redefs [http-client/send-request
+                    (fn [_]
+                      (swap! counter inc)
+                      {:status 200
+                       :headers {"content-type" "application/json"
+                                 "date" "Sat, 01 Jan 2022 15:10:05 GMT"
+                                 "expires" "Sat, 01 Jan 2022 15:40:05 GMT"}
+                       :body "{\"foo\":\"bar\"}"})]
+        (let [res {"body" {"foo" "bar"}
+                   "headers" {"content-type" "application/json"
+                              "date" "Sat, 01 Jan 2022 15:10:05 GMT"
+                              "expires" "Sat, 01 Jan 2022 15:40:05 GMT"}
+                   "raw_body" "{\"foo\":\"bar\"}" "status" "200 OK" "status_code" 200}
+              now   (t/instant (t/zoned-date-time "2022-01-01T15:10:05Z"))
+              exp   (time/instant->ns (t/>> now (t/new-duration 60 :minutes)))
+              bctx {:time-now-ns (time/instant->ns now)}]
+          (is (= (builtin-http-send {:args [req] :builtin-context bctx}) res))
+          (is (= @counter 1))
+          (is (= (builtin-http-send {:args [req] :builtin-context bctx}) res))
+          (is (= @counter 1))
+          (is (= (builtin-http-send {:args [req] :builtin-context {:time-now-ns exp}}) res)) ; fast-forward 1 hour
+          (is (= @counter 2)))))))
 
 (deftest http-send-error-handling-test
   (testing "unknown host error"
-    (is (= (builtin-http-send {:args [{"method" "get" "url" "http://foo.bar"}]})
+    (is (= (builtin-http-send {:args [{"method" "get" "url" "http://foo.bar"}] :builtin-context {:time-now-ns 1}})
            {"error"  {"code"    "eval_http_send_network_error"
                       "message" "Get \"http://foo.bar\": dial tcp: lookup foo.bar: no such host"}
             "status" 0})))
 
   (testing "error response from server"
     (with-redefs [http-client/send-request (fn [_] {:status 500 :headers {} :body "error!"})]
-      (is (= (builtin-http-send {:args [{"method" "get" "url" "http://borge.by"}]})
+      (is (= (builtin-http-send {:args [{"method" "get" "url" "http://borge.by"}] :builtin-context {:time-now-ns 1}})
              {"body"        nil
               "headers"     {}
               "raw_body"    "error!"
@@ -112,14 +207,16 @@
 
   (testing "exception thrown in client, raise_error"
     (with-redefs [http-client/request-fn (fn [_] (throw (ex-info "failed!" {:no :context})))]
-      (let [bt-send #(builtin-http-send {:args [{"method" "get" "url" "http://borge.by"}]})
+      (let [bt-send #(builtin-http-send {:args [{"method" "get" "url" "http://borge.by"}]
+                                         :builtin-context {:time-now-ns 1}})
             ex (errors/try-return bt-send)]
         (is (errors/builtin-ex? ex))
         (is (= (ex-message ex) "http.send: failed!")))))
 
   (testing "exception thrown in client, raise_error: false"
     (with-redefs [http-client/request-fn (fn [_] (throw (ex-info "failed!" {:no :context})))]
-      (is (= (builtin-http-send {:args [{"method" "get" "url" "http://borge.by" "raise_error" false}]})
+      (is (= (builtin-http-send {:args [{"method" "get" "url" "http://borge.by" "raise_error" false}]
+                                 :builtin-context {:time-now-ns 1}})
              {"error"  {"code"    "eval_http_send_network_error"
                         "message" "failed!"}
               "status" 0})))))

--- a/core/src/test/cljc/jarl/builtins/http_test.cljc
+++ b/core/src/test/cljc/jarl/builtins/http_test.cljc
@@ -78,7 +78,21 @@
               "headers"     {}
               "raw_body"    "{\"foo\":\"bar\"}"
               "status"      "200 OK"
-              "status_code" 200})))))
+              "status_code" 200}))))
+
+  (testing "force cache"
+    (let [counter (atom 0)
+          req {"method" "get" "url" "http://borge.by" "force_cache" true "force_cache_duration_seconds" 30}]
+      (with-redefs [http-client/send-request
+                    (fn [_]
+                      (swap! counter inc)
+                      {:status 200 :headers {"content-type" "application/json"} :body "{\"foo\":\"bar\"}"})]
+        (let [res {"body" {"foo" "bar"} "headers" {"content-type" "application/json"}
+                   "raw_body" "{\"foo\":\"bar\"}" "status" "200 OK" "status_code" 200}]
+          (is (= (builtin-http-send {:args [req]}) res))
+          (is (= (builtin-http-send {:args [req]}) res))
+          (is (= (builtin-http-send {:args [req]}) res))
+          (is (= @counter 1)))))))
 
 (deftest http-send-error-handling-test
   (testing "unknown host error"

--- a/core/src/test/cljc/jarl/builtins/time_test.cljc
+++ b/core/src/test/cljc/jarl/builtins/time_test.cljc
@@ -1,21 +1,20 @@
 (ns jarl.builtins.time-test
   (:require [clojure.test :refer [deftest]]
             [tick.core :as t]
-            [jarl.utils :refer [instant->ns ns->instant]]
-            [test.utils :refer [testing-builtin]]
-            [jarl.builtins.time :refer [parse-iso-datetime parse-iso-zoned-datetime]]))
+            [jarl.time :as time]
+            [test.utils :refer [testing-builtin]]))
 
 (deftest builtin-time-add-date-test
   (testing-builtin "time.add_date"
     [0 1 1 1] 34300800000000000))
 
 (deftest builtin-time-clock-test
-  (let [ns (instant->ns (parse-iso-datetime "2022-01-01T01:02:03"))]
+  (let [ns (time/instant->ns (time/parse-iso-datetime "2022-01-01T01:02:03"))]
     (testing-builtin "time.clock"
       [ns] [1 2 3])))
 
 (deftest builtin-time-date-test
-  (let [ns (instant->ns (parse-iso-datetime "2022-03-04T01:02:03"))]
+  (let [ns (time/instant->ns (time/parse-iso-datetime "2022-03-04T01:02:03"))]
     (testing-builtin "time.date"
       [ns] [2022 3 4])))
 
@@ -30,7 +29,7 @@
     {:args [] :builtin-context {:time-now-ns 1655283296943749000}} 1655283296943749000))
 
 (deftest builtin-time-weekday-test
-  (let [ns (instant->ns (parse-iso-datetime "2022-01-01T00:00:00"))]
+  (let [ns (time/instant->ns (time/parse-iso-datetime "2022-01-01T00:00:00"))]
     (testing-builtin "time.weekday"
       [1655283296943749000]      "Wednesday"
       [1656284296943749000]      "Sunday"
@@ -52,8 +51,8 @@
     ["33ks"]                    [:jarl.exceptions/builtin-exception "time: unknown unit \"ks\" in duration \"33ks\""]))
 
 (deftest builtin-time-parse-ns-test
-  (let [ref-time (instant->ns (parse-iso-zoned-datetime "2022-01-01T12:12:12.00-00:00")) ; 1641039132000000000
-        ref-time-tz-offset (instant->ns (-> (ns->instant ref-time) (t/>> (t/of-hours 8))))]
+  (let [ref-time (time/instant->ns (time/parse-iso-zoned-datetime "2022-01-01T12:12:12.00-00:00")) ; 1641039132000000000
+        ref-time-tz-offset (time/instant->ns (-> (time/ns->instant ref-time) (t/>> (t/of-hours 8))))]
     (testing-builtin "time.parse_ns"
       ["Mon Jan 02 15:04:05 2006" "Sat Jan 01 12:12:12 2022"]             ref-time
       ; ANSIC

--- a/doc/builtins.md
+++ b/doc/builtins.md
@@ -273,8 +273,6 @@ Note: `crypto.x509.parse_rsa_private_key` currently only works with PKCS8 format
 |-------------------|:---:|:----:|:-------:|
 | `http.send`       |  ✅  |  ❌   |    ❌    |
 
-Note: Only basic functionality supported currently, i.e. sending requests using the (likely) most common options:
-
 **Supported options**
 
 * `url`
@@ -290,6 +288,8 @@ Note: Only basic functionality supported currently, i.e. sending requests using 
 * `raise_error`
 * `timeout`
 * `tls_insecure_skip_verify`
+* `cache`
+* `caching_mode` (currently always `deserialized`)
 
 **Unsupported options**
 
@@ -303,8 +303,6 @@ Note: Only basic functionality supported currently, i.e. sending requests using 
 * `tls_client_key`
 * `tls_client_key_file`
 * `tls_server_name`
-* `cache`
-* `caching_mode`
 
 The various TLS options do not seem that urgent at this point in time. We'll definitely want to have caching in place
 however, and that is reasonably the next thing to work on here.

--- a/doc/builtins.md
+++ b/doc/builtins.md
@@ -283,6 +283,8 @@ Note: Only basic functionality supported currently, i.e. sending requests using 
 * `raw_body`
 * `headers`
 * `enable_redirect`
+* `force_cache`
+* `force_cache_duration_seconds`
 * `force_json_decode`
 * `force_yaml_decode`
 * `raise_error`
@@ -302,8 +304,6 @@ Note: Only basic functionality supported currently, i.e. sending requests using 
 * `tls_client_key_file`
 * `tls_server_name`
 * `cache`
-* `force_cache`
-* `force_cache_duration_seconds`
 * `caching_mode`
 
 The various TLS options do not seem that urgent at this point in time. We'll definitely want to have caching in place


### PR DESCRIPTION
* Implement `force_cache` option
* Implement `cache` option (i.e response header based)

Both implementations are pretty close to OPA — I've skipped the _server side_ caching (i.e. etags, 304 responses, and all that jazz), as I don't consider that a very good option.

Resolves #122

Signed-off-by: Anders Eknert <anders@eknert.com>