### PR TITLE
Fix jdk version retrieval

### DIFF
--- a/core/src/main/cljc/jarl/time.cljc
+++ b/core/src/main/cljc/jarl/time.cljc
@@ -85,8 +85,10 @@
 
 #?(:clj
    (def ^:private jvm-major-version
-     (let [jvm-version (System/getProperty "java.vm.version")]
-       (parse-long (subs jvm-version 0 (str/index-of jvm-version "."))))))
+     (let [jvm-version (System/getProperty "java.specification.version")]
+       (if-let [dot-idx (str/index-of jvm-version ".")]
+         (parse-long (subs jvm-version (+ dot-idx 1)))
+         (parse-long jvm-version)))))
 
 #?(:clj
    (defn- fixup-am-pm


### PR DESCRIPTION
This fix changes the way the jdk version is retrieved so that it works for openjdk 8, 11 and 21. `java.specification.version` is probably a bit more reliable between different jdk vendors.

Closes #177 